### PR TITLE
Allow cross origin on Vercel deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I created a `vercel.json` file, which is their equivalent of a `netlify.toml` file. This will allow cross origin requests.