### PR TITLE
Update docker image version used

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@
 # https://gitlab.com/pages/hugo/container_registry
 #
 # cState uses Hugo Extended.
-image: registry.gitlab.com/pages/hugo/hugo_extended:0.65.3
+image: registry.gitlab.com/pages/hugo/hugo_extended:0.100.2
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive


### PR DESCRIPTION
This resolves #7, by bumping the version to the latest (as of right now) so that a git executable is available so hugo doesn't fail when it can't execute git.

(I will be away for a while and won't be able to make any changes)